### PR TITLE
Fix date handling for getting challenge LB info.

### DIFF
--- a/djAerolith/wordwalls/locale/es/LC_MESSAGES/django.po
+++ b/djAerolith/wordwalls/locale/es/LC_MESSAGES/django.po
@@ -287,7 +287,7 @@ msgstr "Resultados del desafío"
 
 #: wordwalls/views.py:150
 msgid "No challenge was selected."
-msgstr "No se seleccionó un desafío."
+msgstr "No seleccionó un desafío."
 
 #: wordwalls/views.py:163
 msgid "Challenge does not exist."


### PR DESCRIPTION
Note that Django correctly handles dates otherwise! Since USE_L10N is on, when SUBMITTING a challenge request, the date form validator validates the date properly. We should write tests around this behavior, both for the AJAX get (actually, POST :/ ... ) and for the form POST to start a new challenge.

close #130