### PR TITLE
Don't save flashcard answer to browser history

### DIFF
--- a/djAerolith/whitleyCards/templates/whitleyCards/quiz.html
+++ b/djAerolith/whitleyCards/templates/whitleyCards/quiz.html
@@ -11,7 +11,7 @@
     <div id="messages"></div>
     <form name="game" onSubmit="solve(); return false;" class="form-inline" role="form">
             <div class="form-group">
-                <input type="text" name="word" class="form-control">
+                <input type="text" name="word" class="form-control" autocomplete="off">
             </div>
             <P></P>
             <div class="form-group">


### PR DESCRIPTION
Reasons:
1. UI consistency with wordwalls
2. Slightly annoying when unrelated words show up while typing
3. Kind of cheating if you get the same card