### PR TITLE
[wordvault] Show guess and error message indicating if it matches alphagram or not

### DIFF
--- a/frontend/src/fsrs_cards.tsx
+++ b/frontend/src/fsrs_cards.tsx
@@ -46,7 +46,7 @@ const FSRSCards: React.FC<FSRSCardsProps> = ({
   const { lexicon, displaySettings } = useContext(AppContext);
   const [correctGuesses, setCorrectGuesses] = useState(new Set<string>());
   const [displayQuestion, setDisplayQuestion] = useState("");
-  const [inputError, setInputError] = useState<string | null>(false);
+  const [inputError, setInputError] = useState<string | null>(null);
 
   const [currentCard, setCurrentCard] = useState<WordVaultCard | null>(null);
   const [overdueCount, setOverdueCount] = useState(0);

--- a/frontend/src/fsrs_cards.tsx
+++ b/frontend/src/fsrs_cards.tsx
@@ -46,6 +46,7 @@ const FSRSCards: React.FC<FSRSCardsProps> = ({
   const { lexicon, displaySettings } = useContext(AppContext);
   const [correctGuesses, setCorrectGuesses] = useState(new Set<string>());
   const [displayQuestion, setDisplayQuestion] = useState("");
+  const [inputError, setInputError] = useState<string | null>(false);
 
   const [currentCard, setCurrentCard] = useState<WordVaultCard | null>(null);
   const [overdueCount, setOverdueCount] = useState(0);
@@ -320,6 +321,13 @@ const FSRSCards: React.FC<FSRSCardsProps> = ({
       // Create a new Set and add the guess
       updatedCorrectGuesses = new Set(correctGuesses).add(guess);
       setCorrectGuesses(updatedCorrectGuesses);
+    } else {
+      const guessAlphagram = guess.split("").sort().join("");
+      setInputError(
+        guessAlphagram === currentCard.alphagram.alphagram
+          ? "Word not in lexicon"
+          : "Guess does not match alphagram"
+      );
     }
     // Clear the input
     setTypeInputValue("");
@@ -350,8 +358,11 @@ const FSRSCards: React.FC<FSRSCardsProps> = ({
                   e.preventDefault();
                 }
                 handleGuessEntered();
+              } else {
+                setInputError(null);
               }
             }}
+            error={inputError}
             value={typeInputValue}
           />
           <Group>

--- a/frontend/src/fsrs_cards.tsx
+++ b/frontend/src/fsrs_cards.tsx
@@ -325,8 +325,8 @@ const FSRSCards: React.FC<FSRSCardsProps> = ({
       const guessAlphagram = guess.split("").sort().join("");
       setInputError(
         guessAlphagram === currentCard.alphagram.alphagram
-          ? "Word not in lexicon"
-          : "Guess does not match alphagram"
+          ? `"${guess}" not in lexicon`
+          : `"${guess}" does not match alphagram`
       );
     }
     // Clear the input


### PR DESCRIPTION
Goal here is to show a message which makes it easy to differentiate between:
 1. User misread card, entered something that matches a different alphagram
 2. User knows correct answer but typo'd
 3. User does not know correct answer

Demo https://www.loom.com/share/7765b627821a411eaadfc08de7cb3a6d

Closes https://github.com/domino14/Webolith/issues/470

Manual testing:

 - Confirmed still accepts correct guesses
 - Confirmed alphagram comparison still works even with custom display order