### PR TITLE
[wordvault] Indicate number of remaining cards and missed cards

### DIFF
--- a/frontend/src/flashcard.tsx
+++ b/frontend/src/flashcard.tsx
@@ -121,7 +121,10 @@ const Flashcard: React.FC<FlashcardProps> = ({
           </Text>
           {currentCard.alphagram?.words.map((word) => {
             const highlightAsMissed =
-              missedWords !== undefined && missedWords.has(word.word);
+              missedWords !== undefined &&
+              currentCard.alphagram?.words &&
+              missedWords.size < currentCard.alphagram.words.length &&
+              missedWords.has(word.word);
 
             return (
               <div key={word.word}>

--- a/frontend/src/flashcard.tsx
+++ b/frontend/src/flashcard.tsx
@@ -258,26 +258,6 @@ const Flashcard: React.FC<FlashcardProps> = ({
                 </Center>
                 <Text size="md" c="dimmed">
                   {word.definition}
-          {currentCard.alphagram?.words.map((word) => (
-            <div key={word.word}>
-              <Center>
-                <Text span c="dimmed" size="md" fw={500} mr="xs">
-                  {word.frontHooks}
-                </Text>
-                <Text span c="dimmed" size="md" fw={500}>
-                  {word.innerFrontHook ? "·" : ""}
-                </Text>
-                <Text span size="md" fw={500}>
-                  {word.word}
-                </Text>
-                <Text span c="dimmed" size="md" fw={500}>
-                  {word.innerBackHook ? "·" : ""}
-                </Text>
-                <Text span c="dimmed" size="md" fw={500} ml="xs">
-                  {word.lexiconSymbols}
-                </Text>
-                <Text span c="dimmed" size="md" fw={500}>
-                  {word.backHooks}
                 </Text>
               </div>
             );

--- a/frontend/src/flashcard.tsx
+++ b/frontend/src/flashcard.tsx
@@ -26,6 +26,7 @@ interface FlashcardProps {
   displayQuestion: string;
   origDisplayQuestion: string;
   isPaywalled: boolean;
+  missedWords?: Set<string>;
 }
 
 const Flashcard: React.FC<FlashcardProps> = ({
@@ -38,6 +39,7 @@ const Flashcard: React.FC<FlashcardProps> = ({
   onCustomArrange,
   displayQuestion,
   origDisplayQuestion,
+  missedWords,
 }) => {
   const theme = useMantineTheme();
   const { colorScheme } = useMantineColorScheme();
@@ -117,33 +119,44 @@ const Flashcard: React.FC<FlashcardProps> = ({
           >
             {origDisplayQuestion}
           </Text>
-          {currentCard.alphagram?.words.map((word) => (
-            <div key={word.word}>
-              <Center>
-                <Text span c="dimmed" size="md" fw={500} mr="xs">
-                  {word.frontHooks}
+          {currentCard.alphagram?.words.map((word) => {
+            const highlightAsMissed =
+              missedWords !== undefined && missedWords.has(word.word);
+
+            return (
+              <div key={word.word}>
+                <Center>
+                  <Text span c="dimmed" size="md" fw={500} mr="xs">
+                    {word.frontHooks}
+                  </Text>
+                  <Text span c="dimmed" size="md" fw={500}>
+                    {word.innerFrontHook ? "·" : ""}
+                  </Text>
+                  <Text
+                    span
+                    size="md"
+                    c={highlightAsMissed ? "red" : undefined}
+                    fw={highlightAsMissed ? 700 : 500}
+                    td={highlightAsMissed ? "underline" : undefined}
+                  >
+                    {word.word}
+                  </Text>
+                  <Text span c="dimmed" size="md" fw={500}>
+                    {word.innerBackHook ? "·" : ""}
+                  </Text>
+                  <Text span c="dimmed" size="md" fw={500} ml="xs">
+                    {word.lexiconSymbols}
+                  </Text>
+                  <Text span c="dimmed" size="md" fw={500}>
+                    {word.backHooks}
+                  </Text>
+                </Center>
+                <Text size="md" c="dimmed">
+                  {word.definition}
                 </Text>
-                <Text span c="dimmed" size="md" fw={500}>
-                  {word.innerFrontHook ? "·" : ""}
-                </Text>
-                <Text span size="md" fw={500}>
-                  {word.word}
-                </Text>
-                <Text span c="dimmed" size="md" fw={500}>
-                  {word.innerBackHook ? "·" : ""}
-                </Text>
-                <Text span c="dimmed" size="md" fw={500} ml="xs">
-                  {word.lexiconSymbols}
-                </Text>
-                <Text span c="dimmed" size="md" fw={500}>
-                  {word.backHooks}
-                </Text>
-              </Center>
-              <Text size="md" c="dimmed">
-                {word.definition}
-              </Text>
-            </div>
-          ))}
+              </div>
+            );
+          })}
           <Group mt="sm" justify="space-evenly">
             <Button
               color="red"

--- a/frontend/src/fsrs_cards.tsx
+++ b/frontend/src/fsrs_cards.tsx
@@ -348,7 +348,7 @@ const FSRSCards: React.FC<FSRSCardsProps> = ({
     return `${remainingWords} ${
       remainingWords === 1 ? "word" : "words"
     } remaining…`;
-  }, [currentCard, correctGuesses]);
+  }, [currentCard, correctGuesses, flipped]);
 
   const missedWords: Set<string> | undefined = useMemo(() => {
     if (!typingMode || !currentCard || !currentCard.alphagram) {

--- a/frontend/src/fsrs_cards.tsx
+++ b/frontend/src/fsrs_cards.tsx
@@ -328,10 +328,44 @@ const FSRSCards: React.FC<FSRSCardsProps> = ({
       handleFlip();
     }
   }, [currentCard, correctGuesses, typeInputValue, flipped]);
-
   const sortedGuesses = useMemo(() => {
     return Array.from(correctGuesses).sort((a, b) => a.localeCompare(b));
   }, [correctGuesses]);
+
+  const placeholder = useMemo(() => {
+    if (
+      !currentCard ||
+      !currentCard.alphagram ||
+      correctGuesses.size === 0 ||
+      flipped
+    ) {
+      return "Guess…";
+    }
+
+    const remainingWords =
+      currentCard.alphagram.words.length - correctGuesses.size;
+
+    return `${remainingWords} ${
+      remainingWords === 1 ? "word" : "words"
+    } remaining…`;
+  }, [currentCard, correctGuesses]);
+
+  const missedWords: Set<string> | undefined = useMemo(() => {
+    if (
+      !typingMode ||
+      !currentCard ||
+      !currentCard.alphagram ||
+      correctGuesses.size === 0
+    ) {
+      return undefined;
+    }
+
+    return new Set(
+      currentCard.alphagram.words
+        .map((word) => word.word)
+        .filter((word) => !correctGuesses.has(word))
+    );
+  }, [correctGuesses, typingMode, currentCard]);
 
   return (
     <Center style={{ width: "100%", height: "100%", flexDirection: "column" }}>
@@ -342,7 +376,7 @@ const FSRSCards: React.FC<FSRSCardsProps> = ({
             size="lg"
             autoFocus
             spellCheck="false"
-            placeholder="Guess..."
+            placeholder={placeholder}
             onChange={(e) => setTypeInputValue(e.target.value)}
             onKeyDown={(e) => {
               if (e.key === "Enter" || e.key === " ") {
@@ -370,6 +404,7 @@ const FSRSCards: React.FC<FSRSCardsProps> = ({
           flipped={flipped}
           handleFlip={handleFlip}
           currentCard={currentCard}
+          missedWords={missedWords}
           handleScore={handleScore}
           showLoader={showLoader}
           displayQuestion={displayQuestion}

--- a/frontend/src/fsrs_cards.tsx
+++ b/frontend/src/fsrs_cards.tsx
@@ -334,6 +334,7 @@ const FSRSCards: React.FC<FSRSCardsProps> = ({
 
   const placeholder = useMemo(() => {
     if (
+      !displaySettings.showNumAnagrams ||
       !currentCard ||
       !currentCard.alphagram ||
       correctGuesses.size === 0 ||

--- a/frontend/src/fsrs_cards.tsx
+++ b/frontend/src/fsrs_cards.tsx
@@ -351,12 +351,7 @@ const FSRSCards: React.FC<FSRSCardsProps> = ({
   }, [currentCard, correctGuesses]);
 
   const missedWords: Set<string> | undefined = useMemo(() => {
-    if (
-      !typingMode ||
-      !currentCard ||
-      !currentCard.alphagram ||
-      correctGuesses.size === 0
-    ) {
+    if (!typingMode || !currentCard || !currentCard.alphagram) {
       return undefined;
     }
 

--- a/package.json
+++ b/package.json
@@ -97,6 +97,5 @@
       "^wordvaultapp/(.*)$": "<rootDir>/frontend/src/$1"
     },
     "testEnvironment": "jsdom"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -97,5 +97,6 @@
       "^wordvaultapp/(.*)$": "<rootDir>/frontend/src/$1"
     },
     "testEnvironment": "jsdom"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
Loose suggestion, feel free to reject if you don't prefer this

Solving two issues for me with longer cards
1. It's hard to tell at a glance which words I've actually missed
2. (feel less strongly about this) For a reason I don't deeply understand, I find it helpful to know how many words are left when I'm thinking through a card. The existing horizontal chip list is not easy to count at a glance

Screenshot:

<img width="703" alt="Screenshot 2024-11-23 at 10 44 20 PM" src="https://github.com/user-attachments/assets/87e32b32-b90b-4412-8a35-f5063526907c">

Short video demo:

https://www.loom.com/share/5a099b9a25ec4477a23f2911e0358a31