### PR TITLE
[minor] Search UX tweaks

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -19,7 +19,6 @@ export default tseslint.config(
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
-      'react-hooks/exhaustive-deps': 'error',
       'react-refresh/only-export-components': [
         'warn',
         { allowConstantExport: true },

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -19,6 +19,7 @@ export default tseslint.config(
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
+      'react-hooks/exhaustive-deps': 'error',
       'react-refresh/only-export-components': [
         'warn',
         { allowConstantExport: true },

--- a/frontend/src/search/row.tsx
+++ b/frontend/src/search/row.tsx
@@ -1,8 +1,11 @@
-// SearchRow.tsx
-
 import React from "react";
-import { Select, NumberInput, TextInput, Button, Group } from "@mantine/core";
-import { IconPlus, IconMinus } from "@tabler/icons-react";
+import {
+  Select,
+  NumberInput,
+  TextInput,
+  Group,
+  CloseButton,
+} from "@mantine/core";
 import {
   SearchTypesEnum,
   searchCriteriaOptions,
@@ -161,7 +164,6 @@ interface SearchRowProps {
   searchCriterion: SearchCriterion;
   minAllowedValue?: number;
   maxAllowedValue?: number;
-  addRow: () => void;
   removeRow: (index: number) => void;
   removeDisabled: boolean;
   modifySearchType: (index: number, value: number) => void;
@@ -178,7 +180,6 @@ const SearchRow: React.FC<SearchRowProps> = ({
   searchCriterion,
   minAllowedValue = 1,
   maxAllowedValue = 100,
-  addRow,
   removeRow,
   removeDisabled,
   modifySearchType,
@@ -246,28 +247,9 @@ const SearchRow: React.FC<SearchRowProps> = ({
 
   return (
     <Group>
-      <Group wrap="nowrap" align="center">
-        <Button
-          variant="light"
-          color="blue"
-          onClick={addRow}
-          size="lg"
-          style={{ marginTop: 25 }}
-        >
-          <IconPlus size="md" />
-        </Button>
-
-        <Button
-          variant="light"
-          color="blue"
-          onClick={() => removeRow(index)}
-          disabled={removeDisabled}
-          size="lg"
-          style={{ marginTop: 25 }}
-        >
-          <IconMinus size="md" />
-        </Button>
+      <Group wrap="nowrap">
         <Select
+          w="100%"
           label="Search Criterion"
           value={String(searchCriterion.searchType)}
           data={searchCriteriaOptions(allowedSearchTypes).map((el) => ({
@@ -280,8 +262,16 @@ const SearchRow: React.FC<SearchRowProps> = ({
           size="lg"
         />
       </Group>
-
-      <Group wrap="nowrap">{specificForm}</Group>
+      <Group wrap="nowrap" align="center">
+        {specificForm}
+        <CloseButton
+          variant=""
+          onClick={() => removeRow(index)}
+          disabled={removeDisabled}
+          mt={25}
+          size="lg"
+        />
+      </Group>
     </Group>
   );
 };

--- a/frontend/src/search/rows.tsx
+++ b/frontend/src/search/rows.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { SearchTypesEnum, SearchCriterion, optionType } from "./types";
 import SearchRow from "./row";
-import { Divider } from "@mantine/core";
+import { Button, Divider, Group, Stack } from "@mantine/core";
+import { IconPlus } from "@tabler/icons-react";
 
 interface SearchRowsProps {
   criteria: SearchCriterion[];
@@ -18,7 +19,7 @@ interface SearchRowsProps {
 
 const SearchRows: React.FC<SearchRowsProps> = (props) => {
   return (
-    <div>
+    <Stack>
       {props.criteria.map((criterion, idx) => (
         <React.Fragment key={`fragment${idx}`}>
           <SearchRow
@@ -30,17 +31,29 @@ const SearchRows: React.FC<SearchRowsProps> = (props) => {
             maxAllowedValue={
               SearchTypesEnum.properties[criterion.searchType].maxAllowed
             }
-            addRow={props.addSearchRow}
             removeRow={props.removeSearchRow}
             removeDisabled={idx === 0 && props.criteria.length === 1}
             modifySearchType={props.modifySearchType}
             modifySearchParam={props.modifySearchParam}
             allowedSearchTypes={props.allowedSearchTypes}
           />
-          <Divider my="md" />
         </React.Fragment>
       ))}
-    </div>
+
+      <Group>
+        <Button
+          variant="transparent"
+          onClick={props.addSearchRow}
+          color="gray"
+          size="compact-lg"
+          leftSection={<IconPlus />}
+        >
+          Add Criteria
+        </Button>
+      </Group>
+
+      <Divider my="md" />
+    </Stack>
   );
 };
 

--- a/frontend/src/search/rows.tsx
+++ b/frontend/src/search/rows.tsx
@@ -48,7 +48,7 @@ const SearchRows: React.FC<SearchRowsProps> = (props) => {
           size="compact-lg"
           leftSection={<IconPlus />}
         >
-          Add Criteria
+          Add Criterion
         </Button>
       </Group>
 


### PR DESCRIPTION
Very minor search UX tweaks, feel free to reject or leave suggestions

Desktop:

<img width="600" alt="Screenshot 2024-11-23 at 11 39 37 PM" src="https://github.com/user-attachments/assets/d24e3775-a75c-4cfe-86d3-bbb2a070bb69">

Mobile:

<img width="250" alt="Screenshot 2024-11-23 at 11 39 30 PM" src="https://github.com/user-attachments/assets/0e2f4e96-8882-41b8-86fa-4a3eb262b892">

Explaining my thought process:
 - The `+`/`-` button UX was a tad confusing: The `-` was a row-specific action: clicking it removed the selected row. But the `+` had no bearing on the row that it was in, each `+` button had the exact same effect when clicking it
 - Most other changes are just downstream of the `+`/`-` button changes. When they aren't aligned next to each other, I prefer the layout with the `X` at the end. I also slightly prefer the `+ Add` button being lower in the visual hierarchy than the `Add Matches to WordVault` button
