### PR TITLE
[wordvault] Improve responsiveness of card view

### DIFF
--- a/frontend/src/flashcard.module.css
+++ b/frontend/src/flashcard.module.css
@@ -1,0 +1,23 @@
+.responsiveTileText {
+  font-size: var(--mantine-font-size-xl);
+  line-height: var(--mantine-line-height-xl);
+  letter-spacing: -0.01em;
+}
+
+.responsiveTilePaper {
+  width: calc(2rem * var(--mantine-scale));
+  height: calc(2rem * var(--mantine-scale));
+}
+
+@media (min-width: 48em) {
+  .responsiveTileText {
+    font-size: var(--mantine-font-size-xxl);
+    line-height: var(--mantine-line-height-xxl);
+    letter-spacing: -0.02em;
+  }
+
+  .responsiveTilePaper {
+    width: calc(2.5rem * var(--mantine-scale));
+    height: calc(2.5rem * var(--mantine-scale));
+  }
+}

--- a/frontend/src/flashcard.module.css
+++ b/frontend/src/flashcard.module.css
@@ -1,7 +1,6 @@
 .responsiveTileText {
   font-size: var(--mantine-font-size-xl);
   line-height: var(--mantine-line-height-xl);
-  letter-spacing: -0.01em;
 }
 
 .responsiveTilePaper {
@@ -13,7 +12,6 @@
   .responsiveTileText {
     font-size: var(--mantine-font-size-xxl);
     line-height: var(--mantine-line-height-xxl);
-    letter-spacing: -0.02em;
   }
 
   .responsiveTilePaper {

--- a/frontend/src/flashcard.tsx
+++ b/frontend/src/flashcard.tsx
@@ -143,6 +143,28 @@ const Flashcard: React.FC<FlashcardProps> = ({
   const { displaySettings } = useContext(AppContext);
   const backgroundColor = isDark ? theme.colors.dark[8] : theme.colors.gray[0];
 
+  const shuffleButton = (
+    <Button
+      variant="transparent"
+      size="xs"
+      c={isDark ? theme.colors.gray[8] : theme.colors.gray[5]}
+      onClick={onShuffle}
+    >
+      <IconArrowsShuffle />
+    </Button>
+  );
+
+  const resetArrangementButton = (
+    <Button
+      variant="transparent"
+      size="xs"
+      c={isDark ? theme.colors.gray[8] : theme.colors.gray[5]}
+      onClick={onCustomArrange}
+    >
+      <IconArrowUp />
+    </Button>
+  );
+
   return (
     <Card
       shadow="sm"
@@ -160,14 +182,7 @@ const Flashcard: React.FC<FlashcardProps> = ({
         // Front side
         <Stack align="center" gap="md">
           <Group gap="xs">
-            <Button
-              variant="transparent"
-              size={smallScreen ? "compact-xs" : "xs"}
-              c={isDark ? theme.colors.gray[8] : theme.colors.gray[5]}
-              onClick={onShuffle}
-            >
-              <IconArrowsShuffle />
-            </Button>
+            {!smallScreen && shuffleButton}
             <QuestionDisplay
               displayQuestion={displayQuestion}
               isDark={isDark}
@@ -175,15 +190,14 @@ const Flashcard: React.FC<FlashcardProps> = ({
               fontStyle={displaySettings.fontStyle}
               theme={theme}
             />
-            <Button
-              variant="transparent"
-              size={smallScreen ? "compact-xs" : "xs"}
-              c={isDark ? theme.colors.gray[8] : theme.colors.gray[5]}
-              onClick={onCustomArrange}
-            >
-              <IconArrowUp />
-            </Button>
+            {!smallScreen && resetArrangementButton}
           </Group>
+          {smallScreen && (
+            <Group gap="xs">
+              {shuffleButton}
+              {resetArrangementButton}
+            </Group>
+          )}
           {currentCard.alphagram?.words.length &&
             displaySettings.showNumAnagrams && (
               <Text size="xl" c="dimmed" ta="center">

--- a/frontend/src/flashcard.tsx
+++ b/frontend/src/flashcard.tsx
@@ -43,7 +43,7 @@ type TiledTextProps = {
   };
   text: string;
 } & Pick<PaperProps, "bg" | "c" | "h" | "w" | "withBorder" | "shadow"> &
-  Pick<TextProps, "size" | "fw" | "ff" | "style">;
+  Pick<TextProps, "size" | "fw" | "ff">;
 
 const TiledText: React.FC<TiledTextProps> = ({
   text,

--- a/frontend/src/flashcard.tsx
+++ b/frontend/src/flashcard.tsx
@@ -20,6 +20,7 @@ import React, { useContext } from "react";
 import { IconArrowsShuffle, IconArrowUp } from "@tabler/icons-react";
 import { AppContext, FontStyle, TileStyle } from "./app_context";
 import { useIsSmallScreen } from "./use_is_small_screen";
+import classes from "./flashcard.module.css";
 
 interface FlashcardProps {
   flipped: boolean;
@@ -36,19 +37,23 @@ interface FlashcardProps {
 }
 
 type TiledTextProps = {
+  classNames: {
+    text: string;
+    tile: string;
+  };
   text: string;
 } & Pick<PaperProps, "bg" | "c" | "h" | "w" | "withBorder" | "shadow"> &
-  Pick<TextProps, "size" | "fw" | "ff">;
+  Pick<TextProps, "size" | "fw" | "ff" | "style">;
 
 const TiledText: React.FC<TiledTextProps> = ({
   text,
+  classNames,
   bg,
-  c,
   h,
   w,
   fw,
   ff,
-  size,
+  c,
   withBorder,
   shadow,
 }) => {
@@ -62,9 +67,10 @@ const TiledText: React.FC<TiledTextProps> = ({
           shadow={shadow}
           bg={bg}
           withBorder={withBorder}
+          className={classNames.tile}
         >
           <Center w="100%" h="100%">
-            <Text c={c} size={size} fw={fw} ff={ff} ta="center">
+            <Text className={classNames.text} c={c} fw={fw} ff={ff} ta="center">
               {char}
             </Text>
           </Center>
@@ -89,21 +95,20 @@ const QuestionDisplay: React.FC<QuestionDisplayProps> = ({
   tileStyle,
   theme,
 }) => {
-  const isSmallScreen = useIsSmallScreen();
-
   switch (tileStyle) {
     case TileStyle.MatchDisplay: {
       return (
         <TiledText
-          size={isSmallScreen ? rem(22) : "xxl"}
-          h={rem(isSmallScreen ? 32 : 40)}
-          w={rem(isSmallScreen ? 32 : 40)}
           fw={700}
           ff={fontStyle}
           withBorder={!isDark}
           shadow={isDark ? "xs" : undefined}
           bg={isDark ? theme.colors.gray[8] : theme.colors.gray[4]}
           c={isDark ? theme.colors.gray[0] : undefined}
+          classNames={{
+            text: classes.responsiveTileText,
+            tile: classes.responsiveTilePaper,
+          }}
           text={displayQuestion}
         />
       );

--- a/frontend/src/flashcard.tsx
+++ b/frontend/src/flashcard.tsx
@@ -143,28 +143,6 @@ const Flashcard: React.FC<FlashcardProps> = ({
   const { displaySettings } = useContext(AppContext);
   const backgroundColor = isDark ? theme.colors.dark[8] : theme.colors.gray[0];
 
-  const shuffleButton = (
-    <Button
-      variant="transparent"
-      size="xs"
-      c={isDark ? theme.colors.gray[8] : theme.colors.gray[5]}
-      onClick={onShuffle}
-    >
-      <IconArrowsShuffle />
-    </Button>
-  );
-
-  const resetArrangementButton = (
-    <Button
-      variant="transparent"
-      size="xs"
-      c={isDark ? theme.colors.gray[8] : theme.colors.gray[5]}
-      onClick={onCustomArrange}
-    >
-      <IconArrowUp />
-    </Button>
-  );
-
   return (
     <Card
       shadow="sm"
@@ -181,8 +159,15 @@ const Flashcard: React.FC<FlashcardProps> = ({
       {!flipped ? (
         // Front side
         <Stack align="center" gap="md">
-          <Group>
-            {!smallScreen && shuffleButton}
+          <Group gap="xs">
+            <Button
+              variant="transparent"
+              size={smallScreen ? "compact-xs" : "xs"}
+              c={isDark ? theme.colors.gray[8] : theme.colors.gray[5]}
+              onClick={onShuffle}
+            >
+              <IconArrowsShuffle />
+            </Button>
             <QuestionDisplay
               displayQuestion={displayQuestion}
               isDark={isDark}
@@ -190,14 +175,15 @@ const Flashcard: React.FC<FlashcardProps> = ({
               fontStyle={displaySettings.fontStyle}
               theme={theme}
             />
-            {!smallScreen && resetArrangementButton}
+            <Button
+              variant="transparent"
+              size={smallScreen ? "compact-xs" : "xs"}
+              c={isDark ? theme.colors.gray[8] : theme.colors.gray[5]}
+              onClick={onCustomArrange}
+            >
+              <IconArrowUp />
+            </Button>
           </Group>
-          {smallScreen && (
-            <Group gap="xs">
-              {shuffleButton}
-              {resetArrangementButton}
-            </Group>
-          )}
           {currentCard.alphagram?.words.length &&
             displaySettings.showNumAnagrams && (
               <Text size="xl" c="dimmed" ta="center">


### PR DESCRIPTION
Fixes the "flickering" seen here when progressing to the next card

https://github.com/user-attachments/assets/2b77ee43-c5e3-4fb1-a742-826ef59984c2

The issue here is that `useIsSmallScreen` relies on a media query, which relies on the DOM. Therefore, during re-renders, it's possible for the value to go from `true -> undefined -> true` for a brief moment

This technically affects other visual components if you are specifically looking for it, but it's far more obvious with the tile sizing that anything else, since that shifts the entire layout around

The solution here is to use pure CSS rather than JS to do the styling. I am not a front-end build expert or anything of that sort so definitely open to suggestions on different ways to involve CSS here, css modules seem to be the preferred method for Mantine