### PR TITLE
fix wordwalls timer jumping and backend trusting early end signals

### DIFF
--- a/djAerolith/djaerolith/settings.py
+++ b/djAerolith/djaerolith/settings.py
@@ -334,6 +334,11 @@ LOGGING = {
             "level": "DEBUG" if DEBUG else "INFO",
             "propagate": False,
         },
+        "django.server": {
+            "handlers": ["console"],
+            "level": "WARNING",
+            "propagate": False,
+        },
         "": {  # catch-all
             "handlers": ["console", "mail_admins"],
             "level": "DEBUG" if DEBUG else "INFO",

--- a/djAerolith/wordwalls/game.py
+++ b/djAerolith/wordwalls/game.py
@@ -56,6 +56,10 @@ from wordwalls.stats_service import StatsService
 
 logger = logging.getLogger(__name__)
 
+# Grace window (seconds) to absorb network/latency jitter when the
+# frontend reports the timer ended slightly before the server clock agrees.
+TIMER_END_GRACE_SECS = 0
+
 
 class GameInitException(Exception):
     pass
@@ -662,6 +666,10 @@ class WordwallsGame(object):
         # internal function; not meant to be called by the outside
         return (state["quizStartTime"] + state["timerSecs"]) < time.time()
 
+    def server_time_remaining(self, state):
+        # internal function; not meant to be called by the outside
+        return (state["quizStartTime"] + state["timerSecs"]) - time.time()
+
     def get_wgm(self, tablenum, lock=True):
         """
         Get word game model.
@@ -683,12 +691,17 @@ class WordwallsGame(object):
         # XXX: This function could be called multiple times from different
         # clients. The lock in get_wgm should do the right thing here,
         # but we should figure out how to test this.
+        #
+        # Returns:
+        #   {"ended": True}                               game ended (or already over)
+        #   {"ended": False, "timeRemaining": <float>}   rejected; client should resync
+        #   error string                                  table does not exist (RPCError)
         wgm = self.get_wgm(tablenum)
         if not wgm:
             return _("Table does not exist.")
 
         state = json.loads(wgm.currentGameState)
-        timer_ran_out = self.did_timer_run_out(state)
+        remaining = self.server_time_remaining(state)
         quiz_going = state["quizGoing"]
 
         def end_game():
@@ -697,14 +710,20 @@ class WordwallsGame(object):
             wgm.currentGameState = json.dumps(state)
             wgm.save()
 
-        if timer_ran_out and quiz_going:
-            # the game is over! mark it so.
+        if not quiz_going:
+            logger.info("event=round-is-over")
+            return {"ended": True}
+
+        if remaining <= TIMER_END_GRACE_SECS:
             end_game()
-            return True
+            return {"ended": True}
+
+        # Frontend reported time-up but the server clock disagrees. Reject it
+        # and return authoritative remaining time so the client can resync.
         now = time.time()
         logger.info(
             "Got game ended but did not actually end: "
-            "player=%s table=%s list=%s start_time=%f timer=%f now=%f quizGoing=%s elapsed=%s",
+            "player=%s table=%s list=%s start_time=%f timer=%f now=%f quizGoing=%s elapsed=%s remaining=%f",
             wgm.host.username,
             tablenum,
             wgm.word_list.name if wgm.word_list else None,
@@ -713,18 +732,10 @@ class WordwallsGame(object):
             now,
             state["quizGoing"],
             now - state["quizStartTime"],
+            remaining,
         )
-        if not timer_ran_out:
-            # Log this, but end the game anyway. What else are we going
-            # to do? Otherwise, front end just gets stuck.
-            logger.info("event=ran-out-too-early")
-            end_game()
-            return True
-        if not quiz_going:
-            logger.info("event=round-is-over")
-            return _("The round is over.")
-
-        return False
+        logger.info("event=ran-out-too-early")
+        return {"ended": False, "timeRemaining": remaining}
 
     def allow_give_up(self, wgm, user):
         """

--- a/djAerolith/wordwalls/rpc.py
+++ b/djAerolith/wordwalls/rpc.py
@@ -122,10 +122,10 @@ def giveup(user, tableid, params):
 
 def game_timer_ended(user, tableid, params):
     wwg = WordwallsGame()
-    success = wwg.check_game_ended(tableid)
-    if success is not True:
-        raise RPCError(success)
-    return True
+    result = wwg.check_game_ended(tableid)
+    if isinstance(result, str):  # table does not exist
+        raise RPCError(result)
+    return result  # {"ended": bool, "timeRemaining"?: float}
 
 
 def save_game(user, tableid, params):

--- a/djAerolith/wordwalls/rpc.py
+++ b/djAerolith/wordwalls/rpc.py
@@ -1,5 +1,6 @@
 # RPC endpoint for actual wordwalls game.
 import json
+import logging
 
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.http import require_POST
@@ -8,6 +9,8 @@ from wordwalls.game import WordwallsGame
 from lib.response import bad_request, response
 
 # from wordwalls.socket_consumers import broadcast_to_table, BroadcastTypes
+
+logger = logging.getLogger(__name__)
 
 
 class RPCError(Exception):
@@ -72,6 +75,7 @@ def table_rpc(request, tableid):
     handler = method_lookup(method)
     if not handler:
         return bad_rpc_response(req_id, "RPC method {} does not exist.".format(method))
+    logger.info("event=rpc user=%s table=%s method=%s", request.user.username, tableid, method)
     try:
         ret = handler(request.user, tableid, params)
     except RPCError as e:

--- a/djAerolith/wordwalls/static/js/wordwalls/test/game_timer.test.tsx
+++ b/djAerolith/wordwalls/static/js/wordwalls/test/game_timer.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import GameTimer from '../topbar/game_timer';
+
+describe('GameTimer', () => {
+  let nowMs: number;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    nowMs = 0;
+    jest.spyOn(performance, 'now').mockImplementation(() => nowMs);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  function advance(ms: number) {
+    nowMs += ms;
+    jest.advanceTimersByTime(ms);
+  }
+
+  it('displays the initial time', () => {
+    const { getByText } = render(
+      <GameTimer gameGoing initialGameTime={6000} />
+    );
+    expect(getByText('00:06')).toBeTruthy();
+  });
+
+  it('counts down using the monotonic deadline', () => {
+    const { getByText } = render(
+      <GameTimer gameGoing initialGameTime={6000} interval={500} />
+    );
+    act(() => { advance(2000); });
+    expect(getByText('00:04')).toBeTruthy();
+  });
+
+  it('fires completeCallback exactly once when deadline is reached', () => {
+    const cb = jest.fn();
+    render(
+      <GameTimer gameGoing initialGameTime={3000} interval={500} completeCallback={cb} />
+    );
+    act(() => { advance(3000); });
+    // Drive a few more ticks to confirm it doesn't fire again
+    act(() => { advance(2000); });
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire completeCallback before the deadline', () => {
+    const cb = jest.fn();
+    render(
+      <GameTimer gameGoing initialGameTime={5000} interval={500} completeCallback={cb} />
+    );
+    act(() => { advance(4000); });
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('is immune to a wall-clock style jump between ticks', () => {
+    // In the old Date.now()-based implementation, if performance.now() jumped
+    // by 5000ms between ticks on a 6000ms timer the remaining would instantly
+    // drop to ~1000ms and the callback would fire way too early. The deadline-
+    // based model just re-measures from the fixed deadline so the display is
+    // correct regardless of how large a single dt is.
+    const cb = jest.fn();
+    render(
+      <GameTimer gameGoing initialGameTime={6000} interval={500} completeCallback={cb} />
+    );
+    // Simulate one normal tick
+    act(() => { advance(500); });
+    // Simulate a huge jump (like an NTP correction or tab unsuspend)
+    act(() => { advance(4500); });
+    // Only 5000ms elapsed of a 6000ms timer — should still have ~1s left
+    expect(cb).not.toHaveBeenCalled();
+    // Finish the remaining time
+    act(() => { advance(1000); });
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets when resetNonce is bumped (resync path)', () => {
+    const cb = jest.fn();
+    const { rerender } = render(
+      <GameTimer gameGoing initialGameTime={6000} interval={500} completeCallback={cb} resetNonce={0} />
+    );
+    // Count down 4 seconds
+    act(() => { advance(4000); });
+    expect(cb).not.toHaveBeenCalled();
+
+    // Server resyncs: same initialGameTime but nonce changes
+    act(() => {
+      rerender(
+        <GameTimer gameGoing initialGameTime={6000} interval={500} completeCallback={cb} resetNonce={1} />
+      );
+    });
+    // Should have a fresh 6s deadline — advancing only 4s more shouldn't fire
+    act(() => { advance(4000); });
+    expect(cb).not.toHaveBeenCalled();
+    // Finishing the full 6s from resync should fire
+    act(() => { advance(2000); });
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops and resets to 0 when gameGoing becomes false', () => {
+    const cb = jest.fn();
+    const { rerender, getByText } = render(
+      <GameTimer gameGoing initialGameTime={6000} interval={500} completeCallback={cb} />
+    );
+    act(() => { advance(1000); });
+    act(() => {
+      rerender(<GameTimer gameGoing={false} initialGameTime={6000} interval={500} completeCallback={cb} />);
+    });
+    expect(getByText('00:00')).toBeTruthy();
+    act(() => { advance(10000); });
+    expect(cb).not.toHaveBeenCalled();
+  });
+});

--- a/djAerolith/wordwalls/static/js/wordwalls/topbar/game_timer.tsx
+++ b/djAerolith/wordwalls/static/js/wordwalls/topbar/game_timer.tsx
@@ -4,7 +4,7 @@
  * MIT licensed.
  */
 
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 
 const getFormattedTime = (milliseconds: number): string => {
   let seconds: number | string;
@@ -25,6 +25,9 @@ interface GameTimerProps {
   interval?: number;
   completeCallback?: (() => void) | null;
   warningCountdown?: number;
+  // Bump this to force a timer resync even when initialGameTime is value-equal
+  // (e.g. when the backend rejects an early timerEnded and returns the same ms).
+  resetNonce?: number;
 }
 
 function GameTimer({
@@ -33,106 +36,73 @@ function GameTimer({
   interval = 500,
   completeCallback = null,
   warningCountdown = 10000,
+  resetNonce = 0,
 }: GameTimerProps) {
   const [timeRemaining, setTimeRemaining] = useState<number>(initialGameTime);
-  const [prevTime, setPrevTime] = useState<number | null>(null);
+
+  // deadline is performance.now() + initialGameTime, set on each (re)start.
+  // Using performance.now() makes the countdown monotonic: an NTP/wall-clock
+  // jump cannot move it, so a stalled tick merely delays the display update
+  // instead of subtracting phantom time from the remaining count.
+  const deadlineRef = useRef<number | null>(null);
   const timeoutIdRef = useRef<number | null>(null);
-
-  // Use refs to store current values for the tick function
-  const timeRemainingRef = useRef<number>(timeRemaining);
-  const prevTimeRef = useRef<number | null>(prevTime);
-  const gameGoingRef = useRef<boolean>(gameGoing);
-  const initialGameTimeRef = useRef<number>(initialGameTime);
+  const firedRef = useRef<boolean>(false);
   const completeCallbackRef = useRef<(() => void) | null>(completeCallback);
-
-  // Update refs when state/props change
-  useEffect(() => {
-    timeRemainingRef.current = timeRemaining;
-  }, [timeRemaining]);
-
-  useEffect(() => {
-    prevTimeRef.current = prevTime;
-  }, [prevTime]);
-
-  useEffect(() => {
-    gameGoingRef.current = gameGoing;
-  }, [gameGoing]);
-
-  useEffect(() => {
-    initialGameTimeRef.current = initialGameTime;
-  }, [initialGameTime]);
 
   useEffect(() => {
     completeCallbackRef.current = completeCallback;
   }, [completeCallback]);
 
-  const tick = useCallback(() => {
-    const currentTime = Date.now();
-    const dt = prevTimeRef.current ? (currentTime - prevTimeRef.current) : 0;
-
-    // correct for small variations in actual timeout time
-    const timeRemainingInInterval = (interval - (dt % interval));
-    let timeout = timeRemainingInInterval;
-
-    if (timeRemainingInInterval < (interval / 2.0)) {
-      timeout += interval;
-    }
-
-    const newTimeRemaining = Math.max(timeRemainingRef.current - dt, 0);
-    const countdownComplete = (prevTimeRef.current && newTimeRemaining <= 0);
-
+  const clearPending = useCallback(() => {
     if (timeoutIdRef.current) {
       clearTimeout(timeoutIdRef.current);
+      timeoutIdRef.current = null;
     }
+  }, []);
 
-    timeoutIdRef.current = countdownComplete ? null : window.setTimeout(tick, timeout);
-    setPrevTime(currentTime);
-    setTimeRemaining(newTimeRemaining);
+  const tick = useCallback(() => {
+    if (deadlineRef.current === null) return;
 
-    if (countdownComplete && initialGameTimeRef.current && gameGoingRef.current) {
-      if (completeCallbackRef.current) {
-        completeCallbackRef.current();
-      }
-    }
-  }, [interval]);
+    const remaining = Math.max(deadlineRef.current - performance.now(), 0);
+    setTimeRemaining(remaining);
 
-  // Handle game state changes
-  useEffect(() => {
-    if (!gameGoing) {
-      setPrevTime(null);
-      setTimeRemaining(0);
-      if (timeoutIdRef.current) {
-        clearTimeout(timeoutIdRef.current);
-        timeoutIdRef.current = null;
+    if (remaining <= 0) {
+      clearPending();
+      if (!firedRef.current) {
+        firedRef.current = true;
+        completeCallbackRef.current?.();
       }
       return;
     }
 
-    // Game is starting - reset the timer
-    setPrevTime(null);
-    setTimeRemaining(initialGameTime);
-  }, [gameGoing, initialGameTime]);
+    // Align next wake-up to the interval grid so the display updates smoothly,
+    // but never schedule past the deadline.
+    const timeIntoInterval = performance.now() % interval;
+    const next = Math.min(interval - timeIntoInterval, remaining);
+    timeoutIdRef.current = window.setTimeout(tick, next);
+  }, [interval, clearPending]);
 
-  // Start ticking when component mounts or when timer should start
+  // (Re)start or stop whenever game state, initial time, or the resync nonce changes.
   useEffect(() => {
-    if (!prevTime && timeRemaining > 0 && gameGoing) {
-      tick();
+    clearPending();
+    if (!gameGoing || initialGameTime <= 0) {
+      deadlineRef.current = null;
+      setTimeRemaining(0);
+      return;
     }
-  }, [prevTime, timeRemaining, gameGoing, tick]);
+    deadlineRef.current = performance.now() + initialGameTime;
+    firedRef.current = false;
+    setTimeRemaining(initialGameTime);
+    tick();
+    return clearPending;
+  }, [gameGoing, initialGameTime, resetNonce, tick, clearPending]);
 
   // Cleanup on unmount
-  useEffect(() => () => {
-    if (timeoutIdRef.current) {
-      clearTimeout(timeoutIdRef.current);
-    }
-  }, []);
+  useEffect(() => clearPending, [clearPending]);
 
-  let cn: string;
-  if (timeRemaining <= warningCountdown) {
-    cn = 'badge bg-warning text-dark';
-  } else {
-    cn = 'badge bg-info';
-  }
+  const cn = timeRemaining <= warningCountdown
+    ? 'badge bg-warning text-dark'
+    : 'badge bg-info';
 
   return (
     <span

--- a/djAerolith/wordwalls/static/js/wordwalls/wordwalls_app.tsx
+++ b/djAerolith/wordwalls/static/js/wordwalls/wordwalls_app.tsx
@@ -45,6 +45,7 @@ interface WordwallsAppProps {
   handleGiveup: () => void;
   gameGoing: boolean;
   initialGameTime: number;
+  timerResetNonce: number;
   timerRanOut: () => void;
   numberOfRounds: number;
   isChallenge: boolean;
@@ -92,6 +93,7 @@ const WordwallsApp = forwardRef<WordwallsAppRef, WordwallsAppProps>(({
   handleGiveup,
   gameGoing,
   initialGameTime,
+  timerResetNonce,
   timerRanOut,
   numberOfRounds,
   isChallenge,
@@ -157,6 +159,7 @@ const WordwallsApp = forwardRef<WordwallsAppRef, WordwallsAppProps>(({
         />
         <GameTimer
           initialGameTime={initialGameTime}
+          resetNonce={timerResetNonce}
           completeCallback={timerRanOut}
           gameGoing={gameGoing}
         />

--- a/djAerolith/wordwalls/static/js/wordwalls/wordwalls_app_container.tsx
+++ b/djAerolith/wordwalls/static/js/wordwalls/wordwalls_app_container.tsx
@@ -89,6 +89,7 @@ function WordwallsAppContainer({
 }: WordwallsAppContainerProps) {
   const [gameGoing, setGameGoing] = useState(false);
   const [initialGameTime, setInitialGameTime] = useState(0);
+  const [timerResetNonce, setTimerResetNonce] = useState(0);
   const [origQuestions, setOrigQuestions] = useState(
     game.getOriginalQuestionState()
   );
@@ -407,7 +408,18 @@ function WordwallsAppContainer({
   const timerRanOut = useCallback(() => {
     rpcRef.current
       .timerRanOut()
-      .then(() => processGameEnded())
+      .then((res) => {
+        if (res.ended) {
+          processGameEnded();
+          return;
+        }
+        // Server rejected the early end — resync the countdown to the
+        // authoritative remaining time and keep playing.
+        if (typeof res.timeRemaining === 'number') {
+          setInitialGameTime(res.timeRemaining * 1000);
+          setTimerResetNonce((n) => n + 1);
+        }
+      })
       .catch(error => {
         addMessage(error.message);
       });
@@ -798,6 +810,7 @@ function WordwallsAppContainer({
         handleGiveup={handleGiveup}
         gameGoing={gameGoing}
         initialGameTime={initialGameTime}
+        timerResetNonce={timerResetNonce}
         timerRanOut={timerRanOut}
         numberOfRounds={numberOfRounds}
         isChallenge={isChallenge}

--- a/djAerolith/wordwalls/static/js/wordwalls/wordwalls_rpc.ts
+++ b/djAerolith/wordwalls/static/js/wordwalls/wordwalls_rpc.ts
@@ -17,7 +17,8 @@ interface GiveUpResponse {
 }
 
 interface TimerEndedResponse {
-  [key: string]: unknown;
+  ended: boolean;
+  timeRemaining?: number; // seconds; present when ended === false
 }
 
 class WordwallsRPC extends GenericRPC {

--- a/djAerolith/wordwalls/tests/test_game_logic.py
+++ b/djAerolith/wordwalls/tests/test_game_logic.py
@@ -17,6 +17,7 @@ from django.utils import timezone
 from django.db import connection
 
 from base.forms import SavedListForm
+from unittest.mock import patch
 from wordwalls.game import WordwallsGame, GameInitException
 from wordwalls.models import DailyChallengeName, NamedList, DailyChallenge
 from wordwalls.tests.mixins import WordListAssertMixin
@@ -84,6 +85,56 @@ class WordwallsBasicLogicTest(WordwallsBasicLogicTestBase):
         wgm = wwg.get_wgm(table_id)
         state = json.loads(wgm.currentGameState)
         self.assertFalse(state["quizGoing"])
+
+    def test_check_game_ended_real_timeout(self):
+        table_id, user = self.setup_quiz()
+        wwg = WordwallsGame()
+        wwg.start_quiz(table_id, user)
+        with patch.object(wwg, "server_time_remaining", return_value=-1.0):
+            result = wwg.check_game_ended(table_id)
+        self.assertEqual(result, {"ended": True})
+        wgm = wwg.get_wgm(table_id)
+        state = json.loads(wgm.currentGameState)
+        self.assertFalse(state["quizGoing"])
+
+    def test_check_game_ended_within_grace(self):
+        table_id, user = self.setup_quiz()
+        wwg = WordwallsGame()
+        wwg.start_quiz(table_id, user)
+        # remaining == 0 exactly is still accepted (grace window is 0)
+        with patch.object(wwg, "server_time_remaining", return_value=0.0):
+            result = wwg.check_game_ended(table_id)
+        self.assertEqual(result, {"ended": True})
+        wgm = wwg.get_wgm(table_id)
+        state = json.loads(wgm.currentGameState)
+        self.assertFalse(state["quizGoing"])
+
+    def test_check_game_ended_too_early_rejected(self):
+        table_id, user = self.setup_quiz()
+        wwg = WordwallsGame()
+        wwg.start_quiz(table_id, user)
+        with patch.object(wwg, "server_time_remaining", return_value=120.0):
+            result = wwg.check_game_ended(table_id)
+        self.assertFalse(result["ended"])
+        self.assertAlmostEqual(result["timeRemaining"], 120.0, delta=1.0)
+        # Quiz must still be going
+        wgm = wwg.get_wgm(table_id)
+        state = json.loads(wgm.currentGameState)
+        self.assertTrue(state["quizGoing"])
+
+    def test_check_game_ended_round_already_over(self):
+        table_id, user = self.setup_quiz()
+        wwg = WordwallsGame()
+        wwg.start_quiz(table_id, user)
+        # End the game via give_up first, then call check_game_ended again.
+        wwg.give_up(user, table_id)
+        result = wwg.check_game_ended(table_id)
+        self.assertEqual(result, {"ended": True})
+
+    def test_check_game_ended_no_table(self):
+        wwg = WordwallsGame()
+        result = wwg.check_game_ended(999999)
+        self.assertIsInstance(result, str)
 
     def test_word_list_created(self):
         logger.debug("In test_word_list_created")


### PR DESCRIPTION
Frontend: rewrite GameTimer to use a performance.now() deadline instead of accumulating Date.now() deltas. An NTP clock jump or tab suspension could previously produce a huge dt that was subtracted in one tick, causing the visible timer to leap forward and timerEnded to fire far too early.

Backend: check_game_ended now rejects timerEnded calls where server-side elapsed time is less than timerSecs, returning {"ended": false, "timeRemaining": N} so the frontend can resync its countdown and keep playing. Previously the backend ended the quiz anyway with the comment "What else are we going to do? Otherwise, front end just gets stuck."

Adds 5 backend tests for check_game_ended and 7 frontend tests for the new deadline-based GameTimer including an explicit clock-jump regression.